### PR TITLE
Plugin updates and enhancements

### DIFF
--- a/eslam_me_wordpress_redirect_to_landing_page.php
+++ b/eslam_me_wordpress_redirect_to_landing_page.php
@@ -3,7 +3,7 @@
  * Plugin Name: Redirect wordpress to welcome or landing page.
  * Plugin URI: http://eslam.me
  * Description: Easy simple to the point plug-in allow you to set page so users get redirected to it if they landed on your home page or any page or post
- * Version: 2.0
+ * Version: 2.1
  * Author: Eslam Mahmoud
  * Author URI: http://eslam.me
  * License: GPL2
@@ -12,196 +12,22 @@
 //Blocking direct access to the plugin
 defined('ABSPATH') or die("No script kiddies please!");
 
-//check if the function was not already defined
-if( !function_exists("eslam_me_wordpress_redirect_to_landing_page")){
-	function eslam_me_wordpress_redirect_to_landing_page(){
-		//if the user have the cookie that say he redirected before
-		//then do not redirect him again
-		//cookie expires in one week
-		if(isset($_COOKIE['eslam_me_wordpress_redirect_to_landing_page_url_visited']) && $_COOKIE['eslam_me_wordpress_redirect_to_landing_page_url_visited']){
-			//Do nothing
-		}
-		elseif (is_feed()) {
-			//If feed page we will do nothing or will be a bug :D
-			//https://wordpress.org/support/topic/rss-feed-not-working-if-redirect-wordpress-to-welcome-or-landing-page-is-on
-		}
-		else{
-			//get landing page url
-			$eslam_me_wordpress_redirect_to_landing_page_url = get_option('eslam_me_wordpress_redirect_to_landing_page_url', false);
-			//get landing page option (all || home)
-			$eslam_me_wordpress_redirect_to_landing_page_for_all_pages = get_option('eslam_me_wordpress_redirect_to_landing_page_for_all_pages', false);
-			//get cookie time
-			$eslam_me_wordpress_redirect_to_landing_page_cookie_time = get_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time', 7);
-			$eslam_me_wordpress_redirect_to_landing_page_cookie_time_type = get_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time_type', 'days');
-			//if user added landing page and option
-			if($eslam_me_wordpress_redirect_to_landing_page_url && $eslam_me_wordpress_redirect_to_landing_page_for_all_pages){
-				//if user option is "all" then redirect on all pages
-				//OR if user option is "home" && the user now visiting the home page then redirect him
-				if( $eslam_me_wordpress_redirect_to_landing_page_for_all_pages == 'all' || ($eslam_me_wordpress_redirect_to_landing_page_for_all_pages == 'home' && is_front_page()) ) {
-					//caclulate cookie time
-					switch ($eslam_me_wordpress_redirect_to_landing_page_cookie_time_type) {
-						case 'days':
-							$eslam_me_wordpress_redirect_to_landing_page_cookie_time = $eslam_me_wordpress_redirect_to_landing_page_cookie_time*24*60*60;
-							break;
-						
-						case 'hours':
-							$eslam_me_wordpress_redirect_to_landing_page_cookie_time = $eslam_me_wordpress_redirect_to_landing_page_cookie_time*60*60;
-							break;
-						
-						case 'minutes':
-							$eslam_me_wordpress_redirect_to_landing_page_cookie_time = $eslam_me_wordpress_redirect_to_landing_page_cookie_time*60;
-							break;
-					}
-					//set the cookie that say the user visited the landing page
-					//and set the expiration date to be one week from now
-					setcookie('eslam_me_wordpress_redirect_to_landing_page_url_visited', true, time()+$eslam_me_wordpress_redirect_to_landing_page_cookie_time);
-					//redirect the user to the landing page
-					header("Location: ". $eslam_me_wordpress_redirect_to_landing_page_url);
-					//exit the plugin script
-					die();
-				}
-			}
-		}
-	}
+require_once plugin_dir_path( __FILE__ ) . "inc/init.php";
 
-	//add our function to the hook
-	add_action('wp', 'eslam_me_wordpress_redirect_to_landing_page');
-}
+use eslam\redirect\Init;
 
-/** Step 2 (from text above). */
-add_action( 'admin_menu', 'eslam_me_wordpress_redirect_to_landing_page_menu' );
+/**
+ * Activation Hook
+ */
+// function activate_eslam_redirect_plugin(){
+  require_once plugin_dir_path( __FILE__ ) . "inc/base/activate.php";
+//   eslam\redirect\Activate::activate_plugin();
+// }
+// register_activation_hook( __FILE__, 'activate_eslam_redirect_plugin' );
+register_activation_hook( __FILE__, array('eslam\redirect\Activate', 'activate_plugin') );
 
-/** Step 1. */
-function eslam_me_wordpress_redirect_to_landing_page_menu() {
-	add_options_page( 'Redirect to landing page plug-in', 'Redirect to welcome or landing page', 'manage_options', 'eslam_me_wordpress_redirect_to_landing_page', 'eslam_me_wordpress_redirect_to_landing_page_options' );
-}
 
-/** Step 3. */
-function eslam_me_wordpress_redirect_to_landing_page_options() {
-	if ( !current_user_can( 'manage_options' ) )  {
-		wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
-	}
-
-//start the display of the plugin page
-echo '
-<div class="wrap">
-	<h2>Redirect wordpress to welcome or landing page.</h2>';
-
-	//If for submitted
-	if (count($_POST)){
-		//if url field submitted (empty or not)
-		if(isset($_POST['landing_page_url'])){
-			//if url field submitted not empty
-			if ($_POST['landing_page_url']) {
-				if(get_option('eslam_me_wordpress_redirect_to_landing_page_url', false)) {
-					update_option('eslam_me_wordpress_redirect_to_landing_page_url', $_POST['landing_page_url']);
-				}else{
-					add_option('eslam_me_wordpress_redirect_to_landing_page_url', $_POST['landing_page_url'], '', 'yes' );
-				}
-
-				//if all_pages field submitted
-				if(isset($_POST['all_pages'])){
-					if(get_option( 'eslam_me_wordpress_redirect_to_landing_page_for_all_pages', false)){
-						update_option( 'eslam_me_wordpress_redirect_to_landing_page_for_all_pages', $_POST['all_pages']);
-					}else{
-						add_option( 'eslam_me_wordpress_redirect_to_landing_page_for_all_pages', $_POST['all_pages'], '', 'yes' );
-					}
-				}
-
-				//save cookie time
-				//if not sent or < 0 set it to 7 days
-				if (!isset($_POST['cookie_time']) || (int) $_POST['cookie_time'] < 0) {
-					$_POST['cookie_time'] = 7;
-					$_POST['cookie_time_type'] = 'days';
-				}
-				if(get_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time', false)) {
-					update_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time', (int) $_POST['cookie_time']);
-				}else{
-					add_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time', (int) $_POST['cookie_time'], '', 'yes' );
-				}
-
-				//save cookie time type
-				//if not sent or not valid value set it to days
-				if (!isset($_POST['cookie_time_type']) || !in_array($_POST['cookie_time_type'], array('days', 'hours', 'minutes'))) {
-					$_POST['cookie_time_type'] = 'days';
-				}
-				if(get_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time_type', false)) {
-					update_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time_type', $_POST['cookie_time_type']);
-				}else{
-					add_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time_type', $_POST['cookie_time_type'], '', 'yes' );
-				}
-			} else {
-				//if url field submitted empty remove the options from DB
-				delete_option('eslam_me_wordpress_redirect_to_landing_page_url');
-				delete_option('eslam_me_wordpress_redirect_to_landing_page_for_all_pages');
-				delete_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time');
-				delete_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time_type');
-			}
-			//TODO: Save the current time stamp and then check on it with cookie creation date
-		}
-		echo '
-			<div class="updated notice is-dismissible" id="message">
-				<p>Redirection settings updated.</p>
-				<button class="notice-dismiss" type="button">
-					<span class="screen-reader-text">Dismiss this notice.</span>
-				</button>
-			</div>';
-	}
-
-	echo '
-	<div class="description">Easy simple to the point plug-in allow you to set page so users get redirected to it if they landed on your home page or any page or post</div>
-	<div class="description">Your visitors will be redirected to the set URL if it is the first time they visit your website and for X days, hours or minutes (you set the number in the configration) if they visit again within the time they will not be redirected again.</div>
-	<br>
-
-	<h2>Redirection Settings</h2>
-	<form action="" method="post">
-		<table class="form-table">
-			<tbody>
-				<tr>
-					<th><label for="landing_page_url">The welcome or landing page URL</label></th>
-					<td>
-						<input type="text" id="landing_page_url" name="landing_page_url" value="'.get_option('eslam_me_wordpress_redirect_to_landing_page_url', '').'"/>
-						<code>http://example.com/landingPage</code>
-					</td>
-				</tr>
-				<tr>
-					<th><label for="cookie_time">Redirect the visitor every</label></th>
-					<td>
-						<input type="text" id="cookie_time" name="cookie_time" value="'.get_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time', '7').'"/>
-						<select name="cookie_time_type">
-							<option ' . (get_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time_type', '')=='days'?'selected="selected"':'') . ' value="days">Days</option>
-							<option ' . (get_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time_type', '')=='hours'?'selected="selected"':'') . ' value="minutes">Hours</option>
-							<option ' . (get_option('eslam_me_wordpress_redirect_to_landing_page_cookie_time_type', '')=='minutes'?'selected="selected"':'') . ' value="minutes">Minutes</option>
-						</select>
-					</td>
-				</tr>
-				<tr>
-					<th><label>Allow redirection on all pages?</label></th>
-					<td>
-						<label>
-							<input type="radio" name="all_pages" value="home" ' . (get_option( 'eslam_me_wordpress_redirect_to_landing_page_for_all_pages', "home")=="home"?'checked':'') . '>Home page only
-						</label>
-						<br>
-						<label>
-							<input type="radio" name="all_pages" value="all" ' . (get_option( 'eslam_me_wordpress_redirect_to_landing_page_for_all_pages', "home")=="all"?'checked':'') . '>All pages
-						</label>
-					</td>
-				</tr>
-				<tr>
-					<th>
-						<input value="Save Changes" type="submit" class="button-primary" id="submitbutton" />
-					</th>
-					<td>
-					</td>
-				</tr>
-			</tbody>
-		</table>
-	</form>
-	<div style=" font-size: 18px;">
-		<a href="https://goo.gl/TBGYZv" target="_blank"><img src="'.plugins_url( 'files/donate-paypal.png', __FILE__ ).'" scale="0" style="float: left; max-width: 150px; padding-right: 20px;"></a>
-		<h4>Show some love &amp; <a href="https://goo.gl/TBGYZv" target="_blank">donate with paypal</a></h4>
-		<p><b>Developed by: </b><a target="_blank" href="http://eslam.me">Eslam Mahmoud</a></p>
-	</div>
-</div>';//pend of div.wrap
-}
-?>
+/**
+ * Intialize all the core classes of plugin
+ */
+if ( class_exists( 'eslam\redirect\Init' ) ) Init::register_Services();

--- a/inc/base/activate.php
+++ b/inc/base/activate.php
@@ -1,0 +1,32 @@
+<?php
+namespace eslam\redirect;
+
+/**
+ * @package EslamRedirectToLandingPage
+ */
+
+require_once plugin_dir_path( __DIR__ ) . "base/controller.php";
+
+class Activate
+{
+  
+  public static function activate_plugin(){
+
+    flush_rewrite_rules();
+
+    $controller = new Controller();
+    $prefix = $controller->slug;
+
+    // Setup presets
+    if( !get_option( $prefix . '_for_all_pages', false ) ) update_option( $prefix . '_for_all_pages', false );
+    if( !get_option( $prefix . '_cookie_time', false ) ) update_option( $prefix . '_cookie_time', 7 );
+    if( !get_option( $prefix . '_cookie_time_type', false ) ) update_option( $prefix . '_cookie_time_type', 'days' );
+
+    // Check if Landing page url has been previously set
+    if( !get_option( $prefix . '_url', false ) ) {
+      // Set transient to display setup landing page notice
+      set_transient( '__eslam_me_instructions', true, 60 );
+    }
+  }
+
+}

--- a/inc/base/controller.php
+++ b/inc/base/controller.php
@@ -1,0 +1,85 @@
+<?php
+namespace eslam\redirect;
+
+/**
+ * @package EslamRedirectToLandingPage
+ */
+
+class Controller
+{
+
+  public $version = '2.0.0';
+
+  public $slug = 'eslam_me_wordpress_redirect_to_landing_page';
+
+  public $plugin_name  = 'Redirect wordpress to welcome or landing page';
+
+  public $plugin;
+
+  public $plugin_path;
+
+  public $plugin_url;
+
+  public function __construct(){
+    $this->plugin_path  = plugin_dir_path( dirname( dirname(__FILE__) ) );
+    $this->plugin_url   = plugin_dir_url( dirname( dirname(__FILE__) ) );
+    $this->plugin = plugin_basename( dirname( dirname( dirname(__FILE__) ) ) ) . '/' . $this->slug . '.php';
+  }
+
+  /**
+   * Template
+   * ---------------------------------------------
+   * @param String | $filename | Name of the template
+   * @return false
+   * ---------------------------------------------
+   **/
+
+	public function template($filename) {
+
+		// check theme
+		$theme = get_template_directory() . "/$this->slug/$filename";
+
+		if (file_exists($theme)) {
+			$path = $theme;
+		} else {
+			$path = $this->plugin_path . "templates/$filename";
+		}
+		return $path;
+
+	}
+
+  /**
+   * Template Include
+   * ---------------------------------------------
+   * @param String  | $template |  Name of the template
+   * @param *       | $data     |  Data to pass to a template
+   * @param String  | $name     |  Data value name
+   * @return false
+   * ---------------------------------------------
+   **/
+
+	public function template_include( $template, $data = null, string $name = null){
+
+		if(isset($name)){ ${$name} = $data; }
+
+    $path = $this->plugin_path . "templates/$template";
+
+		include($path);
+  }
+
+  /**
+   * Redirect
+   * ---------------------------------------------
+   * @param $path | String/Int | url of post id
+   * @return false
+   * ---------------------------------------------
+   **/
+
+	// public function redirect($path) {
+
+	// 	if(is_numeric($path)){ $path = get_permalink($path); }
+	// 	wp_safe_redirect( $path );
+	// 	exit();
+
+  // }
+}

--- a/inc/base/controller.php
+++ b/inc/base/controller.php
@@ -8,7 +8,7 @@ namespace eslam\redirect;
 class Controller
 {
 
-  public $version = '2.0.0';
+  public $version = '2.1';
 
   public $slug = 'eslam_me_wordpress_redirect_to_landing_page';
 
@@ -67,19 +67,4 @@ class Controller
 		include($path);
   }
 
-  /**
-   * Redirect
-   * ---------------------------------------------
-   * @param $path | String/Int | url of post id
-   * @return false
-   * ---------------------------------------------
-   **/
-
-	// public function redirect($path) {
-
-	// 	if(is_numeric($path)){ $path = get_permalink($path); }
-	// 	wp_safe_redirect( $path );
-	// 	exit();
-
-  // }
 }

--- a/inc/base/notices.php
+++ b/inc/base/notices.php
@@ -1,0 +1,33 @@
+<?php
+namespace eslam\redirect;
+
+/**
+ * @package EslamRedirectToLandingPage
+ */
+
+require_once plugin_dir_path( __DIR__ ) . "base/controller.php";
+
+class Notices extends Controller
+{
+
+  public function register() {
+
+    add_action( 'admin_notices', array( $this, 'plugin_activated_notice' ) );
+
+  }
+
+  public function plugin_activated_notice() {
+
+    // Check transient, if available display notice
+    if( get_transient( '__eslam_me_instructions' ) ){
+      echo "<div class='updated notice is-dismissible'>";
+      echo '<p>Add your welcome or landing page URL on the <a href="' . menu_page_url( $this->slug, false ) . '">settings page</a> to get started</p>';
+      echo "</div>";
+
+      /* Delete transient, only display this notice once. */
+      delete_transient( '__eslam_me_instructions' );
+    }
+    
+  }
+
+}

--- a/inc/base/redirect.php
+++ b/inc/base/redirect.php
@@ -1,0 +1,40 @@
+<?php
+namespace eslam\redirect;
+
+/**
+ * @package EslamRedirectToLandingPage
+ */
+
+require_once plugin_dir_path( __DIR__ ) . "base/controller.php";
+require_once plugin_dir_path( __DIR__ ) . "classes/landing_page.php";
+
+class Redirect extends Controller
+{
+
+  public function register() {
+    add_action( 'wp', array( $this, 'redirect_handler' ) );
+
+  }
+
+  public function redirect_handler() {
+
+    // If the user has the cookie set after having visted do nothing so as to not redirect again
+    if( !empty($_COOKIE[$this->slug . '_url_visited']) ) return;
+
+    $landing_page = new LandingPage( $this->slug . '_url_visited' );
+
+    // Check if settings and page are valid
+    if( empty( $landing_page->url ) || !$landing_page->valid_page ) return;
+
+    // Set the cookie that say the user visited the landing page
+    $landing_page->set_cookie();
+
+    // Redirect the user to the landing page
+    $landing_page->redirect();
+
+    // Exit the plugin script
+    die();
+
+  }
+
+}

--- a/inc/classes/landing_page.php
+++ b/inc/classes/landing_page.php
@@ -1,0 +1,99 @@
+<?php
+namespace eslam\redirect;
+
+/**
+ * @package EslamRedirectToLandingPage
+ */
+
+require_once plugin_dir_path( __DIR__ ) . "base/controller.php";
+
+class LandingPage extends Controller
+{
+
+  public $url;
+
+
+  public $redirect_duration;
+
+
+  public $cookie_name;
+
+
+  public $redirect_from;
+
+
+  public $valid_page;
+
+  /**
+   * Landing page construct
+   * 
+   * @param string Name of cookie to set
+   */
+  function __construct( $cookie_name ) {
+
+    $this->cookie_name = $cookie_name;
+
+    // get landing page url
+    $this->url = get_option( $this->slug . '_url', null );
+
+    // get landing page option (all || home)
+    $this->redirect_from = get_option( $this->slug . '_for_all_pages', 'home' );
+
+    $this->valid_page = $this->is_valid_page();
+
+    $this->redirect_duration = $this->get_duration();
+
+  }
+
+  /**
+   * Set cookie
+   */
+  function set_cookie() {
+
+    // get cookie time
+    setcookie( $this->cookie_name, true, $this->redirect_duration );
+    
+  }
+
+  /**
+   * Get duration as set in options
+   * 
+   * @return int duration time stamp
+   */
+  function get_duration() {
+
+    $metric = get_option( $this->slug . '_cookie_time', 7 );
+    $type   = get_option( $this->slug . '_cookie_time_type', 'days' );
+
+    return strtotime("+$metric $type");
+
+  }
+
+  /**
+   * Check if current page is feed or admin page otherwise return if current page is valid
+   * 
+   * @return boolean
+   */
+  function is_valid_page() {
+
+    // If feed page we will do nothing or will be a bug :D
+    // https://wordpress.org/support/topic/rss-feed-not-working-if-redirect-wordpress-to-welcome-or-landing-page-is-on
+    if( is_feed() || is_admin() ) return false;
+
+    return $this->redirect_from === 'all' || ( $this->redirect_from === 'home' && is_front_page() );
+
+  }
+
+  /**
+   * Redirect page
+   */
+  function redirect() {
+
+    header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
+    header("Cache-Control: post-check=0, pre-check=0", false);
+    header("Pragma: no-cache");
+    header("Location: ". $this->url);
+
+    die;
+  }
+}

--- a/inc/init.php
+++ b/inc/init.php
@@ -1,0 +1,57 @@
+<?php 
+namespace eslam\redirect;
+
+/**
+ * @package EslamRedirectToLandingPage
+ */
+require_once plugin_dir_path( __FILE__ ) . "pages/settings.php";
+require_once plugin_dir_path( __FILE__ ) . "base/redirect.php";
+require_once plugin_dir_path( __FILE__ ) . "base/notices.php";
+
+
+final class Init
+{
+  /**
+   *  Store all the classes inside array
+   *  @return array Full list of classes
+   */
+  public static function get_services()
+  {
+    return array(
+      // Settings::class,
+      // Redirect::class,
+      'eslam\redirect\Notices',
+      'eslam\redirect\Settings',
+      'eslam\redirect\Redirect',
+      // 'Notices',
+    );
+  }
+
+  /**
+   * Loop through the classes,initialise and call register function
+   * @return
+   */
+  public static function register_services()
+  {
+    // new Redirect();
+    
+    foreach( self::get_services() as $class ) {
+      $service = self::instantiate( $class );
+      if ( method_exists( $service, 'register' ) ) {
+        $service->register();
+      }
+    }
+  }
+
+  /**
+   * Initialise the class
+   * @param class $class      class from the services array
+   * @return class instance   new instance of class
+   */
+  private static function instantiate( $class )
+  {
+    $service = new $class();
+
+    return $service;
+  }
+}

--- a/inc/pages/settings.php
+++ b/inc/pages/settings.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace eslam\redirect;
+
+/**
+ * @package EslamRedirectToLandingPage
+ */
+
+require_once plugin_dir_path( __DIR__ ) . "base/controller.php";
+
+class Settings extends Controller
+{
+
+  public function register() {
+    add_action( 'admin_init', array( $this, 'add_settings_fields' ) );
+    add_action( 'admin_menu', array( $this, 'add_settings_menu' ) );
+    add_filter( 'plugin_action_links_' .  $this->plugin, array( $this, 'add_settings_link' ) );
+  }
+
+  public function add_settings_link($links) {
+    $settings_link = '<a href="' . menu_page_url( $this->slug, false ) . '">Settings</a>';
+    array_push( $links, $settings_link );
+    return $links;
+  }
+
+  public function add_settings_fields() {
+    $prefix = $this->slug;
+
+    // Add section
+    add_settings_section( 
+      $prefix . '-options-section', 
+      'Redirection Settings', 
+      array( $this, 'redirect_section_options' ), 
+      $prefix . '_settings' 
+    );
+    
+    // Setting: landing Page URL
+    register_setting( $prefix . '-settings-group', $prefix . '_url' );
+    add_settings_field( 
+      $prefix . '_url', 
+      'The welcome or landing page URL', 
+      array( $this, 'page_url_setting' ), 
+      $prefix . '_settings', 
+      $prefix . '-options-section' 
+    );
+    
+    // Setting redirect visitor duration
+    register_setting( $prefix . '-settings-group', $prefix . '_cookie_time' );
+    register_setting( $prefix . '-settings-group', $prefix . '_cookie_time_type' );
+    add_settings_field( 
+      $prefix . '_cookie_time', 
+      'Redirect visitor every ', 
+      array( $this, 'redirect_duration' ), 
+      $prefix . '_settings', 
+      $prefix . '-options-section' 
+    );
+    
+    // Redirect on page selection
+    register_setting( $prefix . '-settings-group', $prefix . '_for_all_pages' );
+    add_settings_field( 
+      $prefix . '_for_all_pages', 
+      'Allow redirect from ', 
+      array( $this, 'redirect_from' ), 
+      $prefix . '_settings', 
+      $prefix . '-options-section' 
+    );
+  }
+
+  public function redirect_section_options() {
+
+  }
+
+  public function page_url_setting() {
+
+    $site_url = get_site_url();
+    $option = get_option($this->slug . '_url');
+    echo "<input type='url' name='" . $this->slug . "_url' value='$option'><code>$site_url/landingPage</code>";
+
+  }
+
+  public function redirect_duration() {
+
+    $option = get_option($this->slug . '_cookie_time');
+    $type = get_option($this->slug . '_cookie_time_type');
+    $valid_types = array( 'minutes', 'hours', 'days' );
+
+    ?>
+    <input type='number' name="<?php echo $this->slug . '_cookie_time'?>" value='<?php echo $option?>'>
+    <select name="<?php echo $this->slug . '_cookie_time_type'?>">
+      <?php foreach($valid_types as $valid_type) : ?>
+        <option value='<?php echo $valid_type ?>' <?php echo selected( $valid_type === $type) ?>><?php echo ucfirst($valid_type); ?></option>
+      <?php endforeach ?>
+    </select>
+    <?php
+  }
+
+  public function redirect_from() {
+    
+    $option = get_option($this->slug . '_for_all_pages', 'home');
+
+    $values = array( 
+      'home' => 'Home page only', 
+      'all' => 'All pages' 
+    );
+
+    foreach($values as $key => $value) : ?>
+      <label style='display: block;'>
+        <input type='radio' <?php checked( $key === $option ); ?> name="<?php echo $this->slug . '_for_all_pages'?>" value='<?php echo $key ?>'> 
+        <?php echo $value ?>
+      </label>
+    <?php endforeach;
+
+  }
+
+
+  public function add_settings_menu() {
+
+    $menu_title = str_replace('wordpress ', '', $this->plugin_name);
+    $page_title = str_replace('welcome or ', '', $menu_title);
+
+    add_submenu_page( 
+      'options-general.php', 
+      $page_title,
+      $menu_title,
+      'manage_options',
+      $this->slug,
+      array( $this, 'settings_page_layout' )
+    );
+
+  }
+
+  public function settings_page_layout() {
+    if ( !current_user_can( 'manage_options' ) ) die;
+
+    $this->template_include('settings-form.php');
+
+  }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Hunikal
 Donate link: Eslam Mahmoud
 Tags: redirect, redirection, welcome page, landing page,  opt-in rate, optin rate, opt-in, opt-in-front-page,  eslam.me, optin,  email, email capture, email marketing,  marketing, contest landing page, conversion landing page, announcement, page, easy landing page, ebook landing page, email list, email optin landing page, free landing page, landing page, landing page templates, list building, music landing page, product landing page, video landing page, permalink redirect, Permalink Redirect WordPress Plugin, welcome page plugin wordpress, welcome redirect, wordpress redirection, WordPress Welcome Redirect Plugin
 Requires at least: 3.0.1
-Tested up to: 4.8
+Tested up to: 5.2.4
 Stable tag: 2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -45,6 +45,12 @@ It will not affect your SEO because we use temp redirection code that the search
 1. No screen shots available.
 
 == Changelog ==
+
+= 2.1 =
+* Compatibility with WordPress 5.2
+* Add site name to example url in plugin settings
+* Add default settings on plugin activation
+* Add settings link to plugin action links
 
 = 2.0 =
 * Add long-awaited feature allow admin to set cookie expiration time

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: Eslam Mahmoud
 Tags: redirect, redirection, welcome page, landing page,  opt-in rate, optin rate, opt-in, opt-in-front-page,  eslam.me, optin,  email, email capture, email marketing,  marketing, contest landing page, conversion landing page, announcement, page, easy landing page, ebook landing page, email list, email optin landing page, free landing page, landing page, landing page templates, list building, music landing page, product landing page, video landing page, permalink redirect, Permalink Redirect WordPress Plugin, welcome page plugin wordpress, welcome redirect, wordpress redirection, WordPress Welcome Redirect Plugin
 Requires at least: 3.0.1
 Tested up to: 5.2.4
-Stable tag: 2.0
+Stable tag: 2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/templates/settings-form.php
+++ b/templates/settings-form.php
@@ -1,0 +1,14 @@
+<h2><?php echo $this->plugin_name; ?>.</h2>
+<p>Easy simple to the point plug-in allow you to set page so users get redirected to it if they landed on your home page or any page or post. Your visitors will be redirected to the set URL if it is the first time they visit your website and for X days, hours or minutes (you set the number in the configration) if they visit again within the time they will not be redirected again.</p>
+<form method="post" action="options.php">
+  <?php
+    settings_fields( $this->slug . '-settings-group' );
+    do_settings_sections( $this->slug . '_settings' );
+  ?>
+  <p class="submit"><input type="submit" name="submit" id="submit" class="button button-primary" value="Save Changes"></p>
+</form>
+<div style=" font-size: 18px;">
+	<a href="https://goo.gl/TBGYZv" target="_blank"><img src="<?php echo $this->plugin_url . 'files/donate-paypal.png'; ?>" scale="0" style="float: left; max-width: 150px; padding-right: 20px;"></a>
+	<h4>Show some love &amp; <a href="https://goo.gl/TBGYZv" target="_blank">donate with paypal</a></h4>
+	<p><b>Developed by: </b><a target="_blank" href="http://eslam.me">Eslam Mahmoud</a></p>	
+</div>


### PR DESCRIPTION
**Compatibility**
- [ x ] Tested with PHP 5.3+
- [ x ] Tested from WP 3.0.1+
- [ x ] Tested up to WP 5.2.4
- [ x ] Maintains all setting and field names

**Updates**
* Add WP 5.2.4 compatibility tag
* Add Activation hook to add default settings if not set
* Add notice on activation to add a welcome or landing page URL to the settings page
* Add settings link to plugin action links
* Add site name to url example in settings
* Add additional headers on redirect to help avoid issues with hosts with aggressive cacheing.
* Update version tags to 2.1

**Changes**
* Refactor codebase to OOP file structure
* Use PHP builtin start-time to calculate cookie expiry